### PR TITLE
feat: Add build and release workflow

### DIFF
--- a/.github/workflows/msbuild.yml
+++ b/.github/workflows/msbuild.yml
@@ -1,0 +1,78 @@
+name: Build and Release
+
+on:
+  push:
+    branches:
+      - workflowTest
+
+jobs:
+  build:
+    runs-on: windows-latest
+    
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v2
+
+    - name: Set up MSVC
+      uses: microsoft/setup-msbuild@v1.0.2
+
+    - name: Build .lib file
+      run: |
+        msbuild /p:Configuration=Release /t:RegistryHelper /p:Platform=x64 RegistryHelper.sln
+
+    - name: Upload to Release
+    uses: actions/upload-artifact@v2
+    with:
+        name: lib-artifact
+        path: |
+        x64/Release/RegistryHelper.lib
+        x64/Release/RegistryHelper.pdb
+
+  release:
+    needs: build
+    runs-on: ubuntu-latest
+    
+    steps:
+    - name: Download .lib file
+      uses: actions/download-artifact@v2
+      with:
+        name: lib-artifact
+
+    - name: Generate SHA256 hashes
+      id: hashes
+      run: |
+        for file in lib-artifact/*; do
+          echo "$(basename "$file"): $(sha256sum "$file" | cut -d' ' -f1)" >> hash.txt
+        done
+        echo "::set-output name=hashes::$(cat hash.txt)"
+
+    - name: Upload hashes to Release
+      uses: actions/upload-artifact@v2
+      with:
+        name: hash-artifact
+        path: hash.txt
+
+    - name: Display hashes
+      run: |
+        cat hash.txt
+
+    - name: Create Release
+      id: create_release
+      uses: softprops/action-gh-release@v1
+      with:
+        files: |
+          lib-artifact/*
+          hash-artifact/*
+        data: |
+          { "hashes": "${{ steps.hashes.outputs.hashes }}" }
+
+    - name: Comment on Release
+      run: |
+        echo "Release with hashes: ${{ steps.create_release.outputs.hashes }}" > release_message.txt
+        cat release_message.txt
+      env:
+        RELEASE_HASHES: ${{ steps.create_release.outputs.hashes }}
+        
+    - name: Comment on Release
+      run: |
+        gh release upload ${{ github.repository }} ${{ steps.create_release.outputs.id }} release_message.txt --title "Release Notes"

--- a/Example/Example.vcxproj
+++ b/Example/Example.vcxproj
@@ -127,6 +127,7 @@
       <SDLCheck>true</SDLCheck>
       <PreprocessorDefinitions>NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
+      <AdditionalIncludeDirectories>..\RegistryHelper;</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>

--- a/RegistryHelper/RegistryHelper.vcxproj
+++ b/RegistryHelper/RegistryHelper.vcxproj
@@ -52,7 +52,7 @@
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
-    <ConfigurationType>Application</ConfigurationType>
+    <ConfigurationType>StaticLibrary</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
     <PlatformToolset>v143</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>

--- a/UnitTest/UnitTest.vcxproj
+++ b/UnitTest/UnitTest.vcxproj
@@ -138,15 +138,16 @@
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <ClCompile>
-      <PrecompiledHeader>Use</PrecompiledHeader>
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
       <WarningLevel>Level3</WarningLevel>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <SDLCheck>true</SDLCheck>
-      <AdditionalIncludeDirectories>$(VCInstallDir)UnitTest\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>..\RegistryHelper;$(VCInstallDir)UnitTest\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <UseFullPaths>true</UseFullPaths>
-      <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
+      <PrecompiledHeaderFile>
+      </PrecompiledHeaderFile>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>


### PR DESCRIPTION
Significant changes:
- Set up MSVC for building
- Build `.lib` file using MSBuild
- Upload built artifacts to release
- Download `.lib` file in the release job
- Generate SHA256 hashes for downloaded files
- Upload hashes to release as an artifact
- Create a GitHub release with uploaded files and hashes
- Comment on the created release with the generated hashes

Additionally, there are some changes made to project files:
1. Added an additional include directory in `Example.vcxproj`
2. Changed configuration type to static library in `RegistryHelper.vcxproj`
3. Modified precompiled header settings in `UnitTest.vcxproj`